### PR TITLE
Fix: Show HttpMethods

### DIFF
--- a/SampleProject/Controllers/RoutesController.cs
+++ b/SampleProject/Controllers/RoutesController.cs
@@ -1,6 +1,8 @@
-﻿using System.Linq;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.ActionConstraints;
 using Microsoft.AspNetCore.Mvc.Infrastructure;
+using System.Collections.Generic;
+using System.Linq;
 using System.Text.Json;
 
 namespace RouteDebugging.Controllers
@@ -29,7 +31,7 @@ namespace RouteDebugging.Controllers
                     }),
                     Template = x.AttributeRouteInfo?.Template,
                     Name = x.AttributeRouteInfo?.Name,
-                    Contraint = x.ActionConstraints,
+                    HttpMethods = string.Join(", ", x.ActionConstraints?.OfType<HttpMethodActionConstraint>().First().HttpMethods ?? new List<string>()),
                 }).OrderBy(x => x.Controller).ToList();
 
             return Json(routes, new JsonSerializerOptions


### PR DESCRIPTION
Show all HttpMethods instead of empty object.

Fixes https://github.com/ardalis/AspNetCoreRouteDebugger/issues/11

Before:
```
  {
    "Controller": "XYZ",
    "Action": "Put",
    "Parameters": [
      {
        "Name": "data",
        "Type": "XYZDTO"
      }
    ],
    "Template": "api/XYZ",
    "Name": null,
    "Contraint": [
      {}
    ]
  },
```

After:
```
  {
    "Controller": "XYZ",
    "Action": "Put",
    "Parameters": [
      {
        "Name": "data",
        "Type": "XYZDTO"
      }
    ],
    "Template": "api/XYZ",
    "Name": null,
    "HttpMethods": "PUT, POST"
  },
```